### PR TITLE
Increased the limit of ocean amount and fixed string comparing issue

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,13 @@
     "requireConfigFile": false
   },
   "extends": ["eslint:recommended", "prettier"],
-  "env": { "es6": true, "browser": true, "node": true, "jest": true },
+  "env": {
+    "es6": true,
+    "es2020": true,
+    "browser": true,
+    "node": true,
+    "jest": true
+  },
   "ignorePatterns": ["src/public/"],
   "rules": {
     "no-empty": ["error", { "allowEmptyCatch": true }],

--- a/src/utils/isAllowed.js
+++ b/src/utils/isAllowed.js
@@ -9,10 +9,20 @@ const isAllowed = async (to) => {
     message = `Please enter valid Ethereum Wallet Address`
     return { message, status }
   }
-  const oceanBalance = await getOceanBalance(to)
-  const EthBalance = await getEthBalance(to)
-  const EthBalanceLimit = web3.utils.toWei(process.env.TOKEN_AMOUNT, 'ether')
-  const OceanBalanceLimit = web3.utils.toWei(process.env.TOKEN_AMOUNT, 'ether')
+  const oceanBalance = BigInt(await getOceanBalance(to))
+  const EthBalance = BigInt(await getEthBalance(to))
+  const EthBalanceLimit = BigInt(
+    web3.utils.toWei(
+      process.env.ETH_BALANCE_LIMIT || process.env.TOKEN_AMOUNT,
+      'ether'
+    )
+  )
+  const oceanBalanceLimit = BigInt(
+    web3.utils.toWei(
+      process.env.OCEAN_BALANCE_LIMIT || process.env.TOKEN_AMOUNT,
+      'ether'
+    )
+  )
 
   if (
     // Check Ether balance is below limit
@@ -22,10 +32,10 @@ const isAllowed = async (to) => {
   ) {
     message = `You already have ${process.env.BASE_TOKEN_NAME} in your wallet.\nPlease come back when you require ${process.env.BASE_TOKEN_NAME}`
   } else if (
-    // Check Ether balance is below limit
+    // Check Ocean balance is below limit
     process.env.TOKEN_CONTRACT_ADDRESS !==
       '0x0000000000000000000000000000000000000000' &&
-    oceanBalance > OceanBalanceLimit
+    oceanBalance > oceanBalanceLimit
   ) {
     message = `You already have Ocean in your wallet.\nPlease come back when you require Ocean`
   } else {


### PR DESCRIPTION

Changes proposed in this PR:

Used the variable added in .env: OCEAN_BALANCE_LIMIT
This variable is used as a maximum cap. If the user has more than OCEAN_BALANCE_LIMIT in his account, the faucet will refuse to send more.
@md00ux Once we merge this PR, let's set OCEAN_BALANCE_LIMIT to 2000
